### PR TITLE
Upgrade PyYaml to 3.13 to support Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cached-property==1.3.1
 frozendict==1.2
 genanki==0.5.0
 pystache==0.5.4
-PyYAML==3.12
+PyYAML==3.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cached-property==1.3.1
-frozendict==1.2
+cached-property>=1.3.1
+frozendict>=1.2
 genanki==0.5.0
-pystache==0.5.4
-PyYAML==3.13
+pystache>=0.5.4
+PyYAML>=3.13


### PR DESCRIPTION
PyYaml 3.12 fails to install on Python 3.7