### PR TITLE
Support file format for Glossika Mandarin Taiwan

### DIFF
--- a/glossika-to-anki/glossika_extract_pdf.py
+++ b/glossika-to-anki/glossika_extract_pdf.py
@@ -16,6 +16,7 @@ def main():
     languages = {
         'ZS': ['EN', '简', 'PIN'],  # Simplified Chinese
         'ZH': ['EN', '繁', 'PIN'],  # Traditional Chinese
+        'ZT': ['EN', '繁', 'PIN'],  # Traditional Chinese (Taiwan)
         'YUE': ['EN', '粵', 'YALE'],  # Cantonese | Change YALE to JYUT for Jyutping
         'JA': ['EN', '日', 'ROM']   # Japanese
     }


### PR DESCRIPTION
The ebook files are named like `GLOSSIKA-ENZT-F1-EBK.pdf`.